### PR TITLE
Add comments and test case

### DIFF
--- a/src/query/storages/fuse/Cargo.toml
+++ b/src/query/storages/fuse/Cargo.toml
@@ -50,7 +50,7 @@ parquet-format-safe = "0.2"
 serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = "0.10.6"
-similar-asserts = { version = "1.4.2", features= ["serde"]}
+similar-asserts = { version = "1.4.2", features = ["serde"] }
 siphasher = "0.3.10"
 streaming-decompression = "0.1.2"
 tokio-rayon = "2.1.0"

--- a/src/query/storages/fuse/src/fuse_table.rs
+++ b/src/query/storages/fuse/src/fuse_table.rs
@@ -544,8 +544,8 @@ impl FuseTable {
         }
 
         eprintln!(
-            "new segments: {:?}",
-            serde_json::to_string_pretty(&new_segments)
+            "new segments :\n {}",
+            serde_json::to_string_pretty(&new_segments)?
         );
         eprintln!(
             "statistic of new :\n {}",

--- a/src/query/storages/fuse/src/fuse_table.rs
+++ b/src/query/storages/fuse/src/fuse_table.rs
@@ -516,9 +516,9 @@ impl FuseTable {
         }
         let new_segments: Vec<_> = segments_editor.into_values().collect();
 
-        let chunk_size = 1600;
         let operator = self.operator.clone();
-        let num_threads = 16;
+        let num_threads = ctx.get_settings().get_max_threads()? as usize;
+        let chunk_size = ctx.get_settings().get_max_storage_io_requests()? as usize;
         let mut num_segments_processed = 0;
         let mut stats_acc = FuseStatistics::default();
         let root_segments_len = new_segments.len();

--- a/src/query/storages/fuse/src/fuse_table.rs
+++ b/src/query/storages/fuse/src/fuse_table.rs
@@ -345,6 +345,7 @@ impl FuseTable {
             ));
         }
 
+        eprintln!("processing num of snapshots: 1");
         let root_snapshot = root_snapshot.unwrap();
         // base segments。
         let mut base_segments = root_snapshot.segments.clone();
@@ -394,7 +395,7 @@ impl FuseTable {
             self.meta_location_generator().clone(),
         );
 
-        let mut num_snapshots_processed = 1;
+        let mut num_snapshots_processed = 2;
         // base duplicate segments set.
         let mut base_dup_segments: HashSet<Location> = root_dup_segments.keys().cloned().collect();
         // 丢失并被找回的segment集合。key是其在root snapshot的segment中的index，value为location。

--- a/src/query/storages/fuse/src/fuse_table.rs
+++ b/src/query/storages/fuse/src/fuse_table.rs
@@ -543,7 +543,10 @@ impl FuseTable {
             );
         }
 
-        eprintln!("new segments: {:?}", new_segments);
+        eprintln!(
+            "new segments: {:?}",
+            serde_json::to_string_pretty(&new_segments)
+        );
         eprintln!(
             "statistic of new :\n {}",
             serde_json::to_string_pretty(&stats_acc)?


### PR DESCRIPTION
Test in tag v1.0.6-nightly:
```
mysql> create table t6(c int) block_per_segment=4 row_per_block=3;
s(9);
Query OK, 0 rows affected (0.08 sec)

mysql> insert into t6 select number from numbers(9);
Query OK, 9 rows affected (0.07 sec)

mysql> insert into t6 select number from numbers(18) where number>8;
Query OK, 18 rows affected (0.06 sec)

mysql> optimize table t6 compact segment;
Query OK, 0 rows affected (0.05 sec)

mysql> insert into t6 select number from numbers(27) where number>17;
Query OK, 27 rows affected (0.06 sec)

mysql> insert into t6 values(27);
Query OK, 1 row affected (0.05 sec)

mysql> insert into t6 values(28);
Query OK, 1 row affected (0.04 sec)

mysql> insert into t6 values(29);
Query OK, 1 row affected (0.05 sec)

mysql> insert into t6 values(30);
Query OK, 1 row affected (0.04 sec)

mysql> optimize table t6 compact;
Query OK, 4 rows affected (0.07 sec)

mysql> insert into t6 select number from numbers(40) where number>30;
Query OK, 40 rows affected (0.06 sec)

mysql> insert into t6 select number from numbers(49) where number>39;
Query OK, 49 rows affected (0.06 sec)

mysql> optimize table t6 compact segment;
Query OK, 0 rows affected (0.05 sec)

mysql> optimize table t6 compact;
Query OK, 0 rows affected (0.05 sec)

mysql> insert into t6 select number from numbers(53) where number>48;
Query OK, 53 rows affected (0.06 sec)

mysql> insert into t6 values(53);
Query OK, 1 row affected (0.04 sec)

mysql> insert into t6 values(54);
Query OK, 1 row affected (0.05 sec)

mysql> optimize table t6 compact;
Query OK, 3 rows affected (0.06 sec)

mysql> insert into t6 values(55);
Query OK, 1 row affected (0.04 sec)

mysql> insert into t6 select number from numbers(62) where number>55;
Query OK, 62 rows affected (0.06 sec)

mysql> optimize table t6 compact;
Query OK, 0 rows affected (0.06 sec)

mysql> optimize table t6 compact segment;
Query OK, 0 rows affected (0.03 sec)

mysql> optimize table t6 compact;
Query OK, 0 rows affected (0.06 sec)

mysql> insert into t6 select number from numbers(71) where number>61;
Query OK, 71 rows affected (0.06 sec)

mysql> insert into t6 select number from numbers(80) where number>70;
Query OK, 80 rows affected (0.06 sec)

mysql> optimize table t6 compact segment;
Query OK, 0 rows affected (0.06 sec)

mysql> insert into t6 select number from numbers(89) where number>79;
Query OK, 89 rows affected (0.06 sec)

mysql> insert into t6 values(89);
Query OK, 1 row affected (0.05 sec)

mysql> insert into t6 values(90);
Query OK, 1 row affected (0.05 sec)

mysql> insert into t6 values(91);
Query OK, 1 row affected (0.05 sec)

mysql> insert into t6 values(92);
Query OK, 1 row affected (0.05 sec)

mysql> optimize table t6 compact;
Query OK, 4 rows affected (0.06 sec)

mysql> select * from fuse_snapshot('default', 't6') limit 500;
+----------------------------------+----------------------------------------------------+----------------+----------------------------------+---------------+-------------+-----------+--------------------+------------------+------------+----------------------------+
| snapshot_id                      | snapshot_location                                  | format_version | previous_snapshot_id             | segment_count | block_count | row_count | bytes_uncompressed | bytes_compressed | index_size | timestamp                  |
+----------------------------------+----------------------------------------------------+----------------+----------------------------------+---------------+-------------+-----------+--------------------+------------------+------------+----------------------------+
| 9e44cb23bfd048c094f2021ed1750844 | 1/135/_ss/9e44cb23bfd048c094f2021ed1750844_v2.json |              2 | 1ae2502656064838b30b9281c6079600 |             7 |          39 |       111 |                444 |             7814 |      10866 | 2023-03-24 16:00:39.046204 |
| 1ae2502656064838b30b9281c6079600 | 1/135/_ss/1ae2502656064838b30b9281c6079600_v2.json |              2 | 3714cae3870d4b35b1efef2cc27509e2 |            10 |          38 |       102 |                408 |             7585 |      10581 | 2023-03-24 16:00:38.108126 |
| 3714cae3870d4b35b1efef2cc27509e2 | 1/135/_ss/3714cae3870d4b35b1efef2cc27509e2_v2.json |              2 | 41d277e94b6a4fd1b58a61a6f111ac0c |             9 |          37 |       101 |                404 |             7393 |      10305 | 2023-03-24 16:00:38.060116 |
| 41d277e94b6a4fd1b58a61a6f111ac0c | 1/135/_ss/41d277e94b6a4fd1b58a61a6f111ac0c_v2.json |              2 | dd2dbfb0cde1489eb0bed1d3cc660955 |             8 |          36 |       100 |                400 |             7201 |      10029 | 2023-03-24 16:00:38.009061 |
| dd2dbfb0cde1489eb0bed1d3cc660955 | 1/135/_ss/dd2dbfb0cde1489eb0bed1d3cc660955_v2.json |              2 | 4a23d95c11924396bedf48d31985aad3 |             7 |          35 |        99 |                396 |             7009 |       9753 | 2023-03-24 16:00:37.958978 |
| 4a23d95c11924396bedf48d31985aad3 | 1/135/_ss/4a23d95c11924396bedf48d31985aad3_v2.json |              2 | 20161c85ebaf45489749157b838ae856 |             6 |          34 |        98 |                392 |             6817 |       9477 | 2023-03-24 16:00:37.910693 |
| 20161c85ebaf45489749157b838ae856 | 1/135/_ss/20161c85ebaf45489749157b838ae856_v2.json |              2 | 96625afe7f6e46dd943603d053255614 |             5 |          31 |        89 |                356 |             6214 |       8640 | 2023-03-24 16:00:37.848812 |
| 96625afe7f6e46dd943603d053255614 | 1/135/_ss/96625afe7f6e46dd943603d053255614_v2.json |              2 | ebe6b1930bb84db883709f0d639460df |             6 |          31 |        89 |                356 |             6214 |       8640 | 2023-03-24 16:00:37.795338 |
| ebe6b1930bb84db883709f0d639460df | 1/135/_ss/ebe6b1930bb84db883709f0d639460df_v2.json |              2 | f96e690cd2ca4f31b0b10bf7ca4c4873 |             5 |          28 |        80 |                320 |             5611 |       7803 | 2023-03-24 16:00:37.731553 |
| f96e690cd2ca4f31b0b10bf7ca4c4873 | 1/135/_ss/f96e690cd2ca4f31b0b10bf7ca4c4873_v2.json |              2 | 9d671c01dd434dff9b9a4c59e58b7614 |             4 |          25 |        71 |                284 |             5008 |       6966 | 2023-03-24 16:00:37.669105 |
| 9d671c01dd434dff9b9a4c59e58b7614 | 1/135/_ss/9d671c01dd434dff9b9a4c59e58b7614_v2.json |              2 | 674ee78576b94c8d8728ad2f30e696b6 |             4 |          25 |        71 |                284 |             5008 |       6966 | 2023-03-24 16:00:37.577337 |
| 674ee78576b94c8d8728ad2f30e696b6 | 1/135/_ss/674ee78576b94c8d8728ad2f30e696b6_v2.json |              2 | 8f131c7d54ee42f5a72928eff8a9a4b5 |             6 |          25 |        71 |                284 |             5008 |       6966 | 2023-03-24 16:00:37.520591 |
| 8f131c7d54ee42f5a72928eff8a9a4b5 | 1/135/_ss/8f131c7d54ee42f5a72928eff8a9a4b5_v2.json |              2 | fcb30f2ff05b42b6bfaa7347af9bc184 |             5 |          23 |        65 |                260 |             4606 |       6408 | 2023-03-24 16:00:37.465399 |
| fcb30f2ff05b42b6bfaa7347af9bc184 | 1/135/_ss/fcb30f2ff05b42b6bfaa7347af9bc184_v2.json |              2 | 2f16da92d51245ef9d7f10f1a9a6b491 |             4 |          22 |        64 |                256 |             4414 |       6132 | 2023-03-24 16:00:37.418183 |
| 2f16da92d51245ef9d7f10f1a9a6b491 | 1/135/_ss/2f16da92d51245ef9d7f10f1a9a6b491_v2.json |              2 | 9aa3bfd779dc45f894a1d7462a64a69e |             6 |          24 |        64 |                256 |             4789 |       6681 | 2023-03-24 16:00:37.361137 |
| 9aa3bfd779dc45f894a1d7462a64a69e | 1/135/_ss/9aa3bfd779dc45f894a1d7462a64a69e_v2.json |              2 | 4f88e3f54f5a409887ea5d127d22a026 |             5 |          23 |        63 |                252 |             4597 |       6405 | 2023-03-24 16:00:37.314138 |
| 4f88e3f54f5a409887ea5d127d22a026 | 1/135/_ss/4f88e3f54f5a409887ea5d127d22a026_v2.json |              2 | 4768d101973d41ba92d23c71c28e6eed |             4 |          22 |        62 |                248 |             4405 |       6129 | 2023-03-24 16:00:37.268328 |
| 4768d101973d41ba92d23c71c28e6eed | 1/135/_ss/4768d101973d41ba92d23c71c28e6eed_v2.json |              2 | 5221e05660f446cc8dae6217c54d5290 |             3 |          20 |        58 |                232 |             4012 |       5574 | 2023-03-24 16:00:37.215053 |
| 5221e05660f446cc8dae6217c54d5290 | 1/135/_ss/5221e05660f446cc8dae6217c54d5290_v2.json |              2 | 7cdada205a004a78b50afd41a0c010c3 |             4 |          20 |        58 |                232 |             4012 |       5574 | 2023-03-24 16:00:37.162600 |
| 7cdada205a004a78b50afd41a0c010c3 | 1/135/_ss/7cdada205a004a78b50afd41a0c010c3_v2.json |              2 | e4ead01c10de466aa653040e773037f6 |             5 |          20 |        58 |                232 |             4012 |       5574 | 2023-03-24 16:00:37.110046 |
| e4ead01c10de466aa653040e773037f6 | 1/135/_ss/e4ead01c10de466aa653040e773037f6_v2.json |              2 | c28a6faf5ba44c9688d03466b7a2d1f2 |             4 |          17 |        49 |                196 |             3409 |       4737 | 2023-03-24 16:00:37.050786 |
| c28a6faf5ba44c9688d03466b7a2d1f2 | 1/135/_ss/c28a6faf5ba44c9688d03466b7a2d1f2_v2.json |              2 | 624fa42b8777456199a8ab5e9c5e96aa |             3 |          14 |        40 |                160 |             2806 |       3900 | 2023-03-24 16:00:36.987628 |
| 624fa42b8777456199a8ab5e9c5e96aa | 1/135/_ss/624fa42b8777456199a8ab5e9c5e96aa_v2.json |              2 | 174c54e7f87342fa96e83f7c84da80db |             6 |          13 |        31 |                124 |             2577 |       3615 | 2023-03-24 16:00:36.925537 |
| 174c54e7f87342fa96e83f7c84da80db | 1/135/_ss/174c54e7f87342fa96e83f7c84da80db_v2.json |              2 | 87bcf24019f44b00aafec586fa6f16c3 |             5 |          12 |        30 |                120 |             2385 |       3339 | 2023-03-24 16:00:36.879263 |
| 87bcf24019f44b00aafec586fa6f16c3 | 1/135/_ss/87bcf24019f44b00aafec586fa6f16c3_v2.json |              2 | 96b7ac93853549369b8f976d8428b75a |             4 |          11 |        29 |                116 |             2193 |       3063 | 2023-03-24 16:00:36.834963 |
| 96b7ac93853549369b8f976d8428b75a | 1/135/_ss/96b7ac93853549369b8f976d8428b75a_v2.json |              2 | bd4f58355e974280bc564641bc055edc |             3 |          10 |        28 |                112 |             2001 |       2787 | 2023-03-24 16:00:36.786267 |
| bd4f58355e974280bc564641bc055edc | 1/135/_ss/bd4f58355e974280bc564641bc055edc_v2.json |              2 | 34d4d753139c499cbe56620cb1dd4468 |             2 |           9 |        27 |                108 |             1809 |       2511 | 2023-03-24 16:00:36.742527 |
| 34d4d753139c499cbe56620cb1dd4468 | 1/135/_ss/34d4d753139c499cbe56620cb1dd4468_v2.json |              2 | 7b2e7ead8cc74d88a4b7cf112a4e37fc |             1 |           6 |        18 |                 72 |             1206 |       1674 | 2023-03-24 16:00:36.681852 |
| 7b2e7ead8cc74d88a4b7cf112a4e37fc | 1/135/_ss/7b2e7ead8cc74d88a4b7cf112a4e37fc_v2.json |              2 | 925b9c9163a9436abebcea068e7313a4 |             2 |           6 |        18 |                 72 |             1206 |       1674 | 2023-03-24 16:00:36.629066 |
| 925b9c9163a9436abebcea068e7313a4 | 1/135/_ss/925b9c9163a9436abebcea068e7313a4_v2.json |              2 | NULL                             |             1 |           3 |         9 |                 36 |              603 |        837 | 2023-03-24 16:00:36.569548 |
+----------------------------------+----------------------------------------------------+----------------+----------------------------------+---------------+-------------+-----------+--------------------+------------------+------------+----------------------------+
30 rows in set (0.03 sec)
Read 30 rows, 5.92 KiB in 0.020 sec., 1.5 thousand rows/sec., 296.04 KiB/sec.
```

The snapshot:
```
{
	"format_version": 2,
	"snapshot_id": "9e44cb23-bfd0-48c0-94f2-021ed1750844",
         ...  ...
	"summary": {
		"row_count": 111,
		"block_count": 39,
                 ...  ...
	},
	"segments": [
		["1/135/_sg/8afc048a67ba48e8806c0c11d33e2711_v2.json", 2],
		["1/135/_sg/972d479dff7141ae9eb444f675425721_v2.json", 2],
		["1/135/_sg/972d479dff7141ae9eb444f675425721_v2.json", 2],
		["1/135/_sg/e06c81f6941a41fd87f3784501fb487f_v2.json", 2],
		["1/135/_sg/3842f0de5e244702bd3f14f3c7279243_v2.json", 2],
		["1/135/_sg/2966482a2c434706bd308a2484067613_v2.json", 2],
		["1/135/_sg/2966482a2c434706bd308a2484067613_v2.json", 2]
	],
         ...  ...
}
```

correct:
```
cargo run --bin databend-query -- -c scripts/ci/deploy/config/databend-query-node-1.toml --internal-enable-sandbox-tenant --cmd correct --check-table='t6

exec correct query
all the dup_segments: {("1/135/_sg/2966482a2c434706bd308a2484067613_v2.json", 2): 5, ("1/135/_sg/972d479dff7141ae9eb444f675425721_v2.json", 2): 1}
processing num of snapshots 1
find lost segment:("1/135/_sg/9ad53b32eeb1434187039950fc79a3fa_v2.json", 2) in snapshot_id:1ae25026-5606-4838-b30b-9281c6079600, match the dup segment:("1/135/_sg/972d479dff7141ae9eb444f675425721_v2.json", 2)
processing num of snapshots 2
processing num of snapshots 3
processing num of snapshots 4
processing num of snapshots 5
processing num of snapshots 6
processing num of snapshots 7
processing num of snapshots 8
processing num of snapshots 9
processing num of snapshots 10
processing num of snapshots 11
processing num of snapshots 12
processing num of snapshots 13
processing num of snapshots 14
processing num of snapshots 15
processing num of snapshots 16
processing num of snapshots 17
processing num of snapshots 18
processing num of snapshots 19
processing num of snapshots 20
processing num of snapshots 21
processing num of snapshots 22
find lost segment:("1/135/_sg/b459bb3b91fc4a9799b3b630c33015cb_v2.json", 2) in snapshot_id:624fa42b-8777-4561-99a8-ab5e9c5e96aa, match the dup segment:("1/135/_sg/2966482a2c434706bd308a2484067613_v2.json", 2)
all the lost_segments: {5: ("1/135/_sg/b459bb3b91fc4a9799b3b630c33015cb_v2.json", 2), 1: ("1/135/_sg/9ad53b32eeb1434187039950fc79a3fa_v2.json", 2)}
processing segments 7/7
new segments: [("1/135/_sg/8afc048a67ba48e8806c0c11d33e2711_v2.json", 2), ("1/135/_sg/9ad53b32eeb1434187039950fc79a3fa_v2.json", 2), ("1/135/_sg/972d479dff7141ae9eb444f675425721_v2.json", 2), ("1/135/_sg/e06c81f6941a41fd87f3784501fb487f_v2.json", 2), ("1/135/_sg/3842f0de5e244702bd3f14f3c7279243_v2.json", 2), ("1/135/_sg/b459bb3b91fc4a9799b3b630c33015cb_v2.json", 2), ("1/135/_sg/2966482a2c434706bd308a2484067613_v2.json", 2)]
statistic of new :
 {
  "row_count": 93,
  "block_count": 33,
  "perfect_block_count": 32,
  "uncompressed_byte_size": 372,
  "compressed_byte_size": 6608,
  "index_size": 9192,
  "col_stats": {
    "0": {
      "min": {
        "Number": {
          "Int32": 0
        }
      },
      "max": {
        "Number": {
          "Int32": 92
        }
      },
      "null_count": 0,
      "in_memory_size": 372,
      "distinct_of_values": null
    }
  }
}
```

After correct:
```
mysql> select * from fuse_snapshot('default', 't6')\G
*************************** 1. row ***************************
         snapshot_id: 6d6f160a5bf742598c932c4aeab1e3df
   snapshot_location: 1/135/_ss/6d6f160a5bf742598c932c4aeab1e3df_v2.json
      format_version: 2
previous_snapshot_id: 9e44cb23bfd048c094f2021ed1750844
       segment_count: 7
         block_count: 33
           row_count: 93
  bytes_uncompressed: 372
    bytes_compressed: 6608
          index_size: 9192
           timestamp: 2023-03-24 16:17:22.077084
*************************** 2. row ***************************
         snapshot_id: 9e44cb23bfd048c094f2021ed1750844
   snapshot_location: 1/135/_ss/9e44cb23bfd048c094f2021ed1750844_v2.json
      format_version: 2
previous_snapshot_id: 1ae2502656064838b30b9281c6079600
       segment_count: 7
         block_count: 39
           row_count: 111
  bytes_uncompressed: 444
    bytes_compressed: 7814
          index_size: 10866
           timestamp: 2023-03-24 16:00:39.046204

mysql> select * from t6 order by c;
+------+
| c    |
+------+
|    0 |
|    1 |
|    2 |
|    3 |
|    4 |
|    5 |
|    6 |
|    7 |
|    8 |
|    9 |
|   10 |
|   11 |
|   12 |
|   13 |
|   14 |
|   15 |
|   16 |
|   17 |
|   18 |
|   19 |
|   20 |
|   21 |
|   22 |
|   23 |
|   24 |
|   25 |
|   26 |
|   27 |
|   28 |
|   29 |
|   30 |
|   31 |
|   32 |
|   33 |
|   34 |
|   35 |
|   36 |
|   37 |
|   38 |
|   39 |
|   40 |
|   41 |
|   42 |
|   43 |
|   44 |
|   45 |
|   46 |
|   47 |
|   48 |
|   49 |
|   50 |
|   51 |
|   52 |
|   53 |
|   54 |
|   55 |
|   56 |
|   57 |
|   58 |
|   59 |
|   60 |
|   61 |
|   62 |
|   63 |
|   64 |
|   65 |
|   66 |
|   67 |
|   68 |
|   69 |
|   70 |
|   71 |
|   72 |
|   73 |
|   74 |
|   75 |
|   76 |
|   77 |
|   78 |
|   79 |
|   80 |
|   81 |
|   82 |
|   83 |
|   84 |
|   85 |
|   86 |
|   87 |
|   88 |
|   89 |
|   90 |
|   91 |
|   92 |
+------+
93 rows in set (0.04 sec)
Read 93 rows, 372.00 B in 0.019 sec., 4.9 thousand rows/sec., 19.15 KiB/sec.
``